### PR TITLE
Fix the issue with random password generator

### DIFF
--- a/components/org.wso2.carbon.identity.outbound.provisioning.connector.office365/src/main/java/org/wso2/carbon/identity/outbound/provisioning/connector/office365/Office365ProvisioningConnector.java
+++ b/components/org.wso2.carbon.identity.outbound.provisioning.connector.office365/src/main/java/org/wso2/carbon/identity/outbound/provisioning/connector/office365/Office365ProvisioningConnector.java
@@ -340,6 +340,13 @@ public class Office365ProvisioningConnector extends AbstractOutboundProvisioning
         return accessToken;
     }
 
+    protected String generateRandomPassword() {
+        String randomCapitals = RandomStringUtils.random(3, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+        String randomSimples = RandomStringUtils.random(5, "abcdefghijklmnopqrstuvwxyz");
+        String randomNumbers = RandomStringUtils.randomNumeric(4);
+        return randomCapitals.concat(randomSimples).concat(randomNumbers);
+    }
+
     private JSONObject buildUserAsJson(ProvisioningEntity provisioningEntity) throws IdentityProvisioningException {
 
         Map<String, String> requiredAttributes = getSingleValuedClaims(provisioningEntity.getAttributes());
@@ -367,7 +374,7 @@ public class Office365ProvisioningConnector extends AbstractOutboundProvisioning
             // Create a json object corresponding to the attributes of the user in the request.
             JSONObject passwordProfile = new JSONObject();
             passwordProfile.put(Office365ConnectorConstants.FORCE_CHANGE_PASSWORD, false);
-            passwordProfile.put(Office365ConnectorConstants.PASSWORD, RandomStringUtils.randomAlphanumeric(12));
+            passwordProfile.put(Office365ConnectorConstants.PASSWORD, generateRandomPassword());
 
             JSONObject user = new JSONObject();
             user.put(Office365ConnectorConstants.ACCOUNT_ENABLED, true);

--- a/components/org.wso2.carbon.identity.outbound.provisioning.connector.office365/src/main/java/org/wso2/carbon/identity/outbound/provisioning/connector/office365/Office365ProvisioningConnector.java
+++ b/components/org.wso2.carbon.identity.outbound.provisioning.connector.office365/src/main/java/org/wso2/carbon/identity/outbound/provisioning/connector/office365/Office365ProvisioningConnector.java
@@ -341,6 +341,7 @@ public class Office365ProvisioningConnector extends AbstractOutboundProvisioning
     }
 
     protected String generateRandomPassword() {
+
         String randomCapitals = RandomStringUtils.random(3, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
         String randomSimples = RandomStringUtils.random(5, "abcdefghijklmnopqrstuvwxyz");
         String randomNumbers = RandomStringUtils.randomNumeric(4);


### PR DESCRIPTION
## Purpose
The previous implementation for random password generations does not guarantee that the generated password may contain numerals.