### PR TITLE
Add the update functionality for provisioned user

### DIFF
--- a/components/org.wso2.carbon.identity.outbound.provisioning.connector.office365/src/main/java/org/wso2/carbon/identity/outbound/provisioning/connector/office365/Office365ConnectorConstants.java
+++ b/components/org.wso2.carbon.identity.outbound.provisioning.connector.office365/src/main/java/org/wso2/carbon/identity/outbound/provisioning/connector/office365/Office365ConnectorConstants.java
@@ -36,6 +36,7 @@ public class Office365ConnectorConstants {
     public static final String OFFICE365_MEMBERSHIP_VALUE = "office-365-membership-rule-value";
 
     public static final String WSO2_ROLE_CLAIM = "http://wso2.org/claims/role";
+    public static final String WSO2_USERNAME_CLAIM = "http://wso2.org/claims/username";
 
     public static final String OFFICE365_BASE_URL = "https://login.microsoftonline.com";
     public static final String OFFICE365_TOKEN_ENDPOINT = "/oauth2/v2.0/token";

--- a/components/org.wso2.carbon.identity.outbound.provisioning.connector.office365/src/main/java/org/wso2/carbon/identity/outbound/provisioning/connector/office365/Office365ProvisioningConnector.java
+++ b/components/org.wso2.carbon.identity.outbound.provisioning.connector.office365/src/main/java/org/wso2/carbon/identity/outbound/provisioning/connector/office365/Office365ProvisioningConnector.java
@@ -173,7 +173,7 @@ public class Office365ProvisioningConnector extends AbstractOutboundProvisioning
                 log.debug("Returning provisioned user's ID: " + provisionedId);
             }
         } catch (IOException e) {
-            log.error("Error while closing HttpClient.");
+            log.error("Error while closing HttpClient.", e);
         }
         return provisionedId;
     }
@@ -227,7 +227,7 @@ public class Office365ProvisioningConnector extends AbstractOutboundProvisioning
                         "provisioning.", e);
             }
         } catch (IOException e) {
-            log.error("Error while closing HttpClient.");
+            log.error("Error while closing HttpClient.", e);
         }
     }
 
@@ -275,7 +275,7 @@ public class Office365ProvisioningConnector extends AbstractOutboundProvisioning
                         "provisioning", e);
             }
         } catch (IOException e) {
-            log.error("Error while closing HttpClient.");
+            log.error("Error while closing HttpClient.", e);
         }
     }
 
@@ -325,7 +325,7 @@ public class Office365ProvisioningConnector extends AbstractOutboundProvisioning
             }
 
         } catch (IOException e) {
-            log.error("Error while closing HttpClient.");
+            log.error("Error while closing HttpClient.", e);
         }
     }
 
@@ -383,7 +383,7 @@ public class Office365ProvisioningConnector extends AbstractOutboundProvisioning
                 throw new IdentityProvisioningException("Error while obtaining the access token from the response.", e);
             }
         } catch (IOException e) {
-            log.error("Error while closing HttpClient.");
+            log.error("Error while closing HttpClient.", e);
         }
         return accessToken;
     }

--- a/components/org.wso2.carbon.identity.outbound.provisioning.connector.office365/src/main/java/org/wso2/carbon/identity/outbound/provisioning/connector/office365/Office365ProvisioningConnector.java
+++ b/components/org.wso2.carbon.identity.outbound.provisioning.connector.office365/src/main/java/org/wso2/carbon/identity/outbound/provisioning/connector/office365/Office365ProvisioningConnector.java
@@ -154,11 +154,19 @@ public class Office365ProvisioningConnector extends AbstractOutboundProvisioning
                                 jsonResponse.toString());
                     }
                 } else {
-                    String errorMessage = jsonResponse.getJSONObject("error").getString("message");
-                    log.error("Received response status code: " + response.getStatusLine().getStatusCode() + " "
-                            + response.getStatusLine().getReasonPhrase() + " with the message '" + errorMessage +
-                            "' while creating the user " + user.getString(Office365ConnectorConstants.OFFICE365_UPN) +
-                            " in the Azure Active Directory.");
+                    if (jsonResponse.has("error")) {
+                        String errorMessage = jsonResponse.getJSONObject("error").getString("message");
+                        log.error("Received response status code: " + response.getStatusLine().getStatusCode() + " "
+                                + response.getStatusLine().getReasonPhrase() + " with the message '" + errorMessage +
+                                "' while creating the user " + user.getString(Office365ConnectorConstants
+                                .OFFICE365_UPN) + " in the Azure Active Directory.");
+
+                    } else {
+                        log.error("Received response status code: " + response.getStatusLine().getStatusCode() + " "
+                                + response.getStatusLine().getReasonPhrase() + " while creating the user " + user
+                                .getString(Office365ConnectorConstants.OFFICE365_UPN) + " in the Azure Active " +
+                                "Directory.");
+                    }
 
                     if (log.isDebugEnabled()) {
                         log.debug("The response received from server : " + jsonResponse.toString());
@@ -211,12 +219,18 @@ public class Office365ProvisioningConnector extends AbstractOutboundProvisioning
                 } else {
                     JSONObject jsonResponse = new JSONObject(new JSONTokener(new InputStreamReader(
                             response.getEntity().getContent())));
-                    String errorMessage = jsonResponse.getJSONObject("error").getString("message");
 
-                    log.error("Received response status code: " + response.getStatusLine().getStatusCode() + " "
-                            + response.getStatusLine().getReasonPhrase() + " with the message '" + errorMessage +
-                            "' while updating the user with id " + provisionedUserId + " in the Azure Active " +
-                            "Directory.");
+                    if (jsonResponse.has("error")) {
+                        String errorMessage = jsonResponse.getJSONObject("error").getString("message");
+                        log.error("Received response status code: " + response.getStatusLine().getStatusCode() + " "
+                                + response.getStatusLine().getReasonPhrase() + " with the message '" + errorMessage +
+                                "' while updating the user with id " + provisionedUserId + " in the Azure Active " +
+                                "Directory.");
+                    } else {
+                        log.error("Received response status code: " + response.getStatusLine().getStatusCode() + " "
+                                + response.getStatusLine().getReasonPhrase() + " while updating the user with id " +
+                                provisionedUserId + " in the Azure Active " + "Directory.");
+                    }
 
                     if (log.isDebugEnabled()) {
                         log.debug("The response received from server : " + jsonResponse.toString());
@@ -259,12 +273,18 @@ public class Office365ProvisioningConnector extends AbstractOutboundProvisioning
                 } else {
                     JSONObject jsonResponse = new JSONObject(new JSONTokener(new InputStreamReader(
                             response.getEntity().getContent())));
-                    String errorMessage = jsonResponse.getJSONObject("error").getString("message");
 
-                    log.error("Received response status code: " + response.getStatusLine().getStatusCode() + " "
-                            + response.getStatusLine().getReasonPhrase() + " with the message '" + errorMessage +
-                            "' while deleting the user with id " + provisionedUserId + " from the Azure Active " +
-                            "Directory.");
+                    if (jsonResponse.has("error")) {
+                        String errorMessage = jsonResponse.getJSONObject("error").getString("message");
+                        log.error("Received response status code: " + response.getStatusLine().getStatusCode() + " "
+                                + response.getStatusLine().getReasonPhrase() + " with the message '" + errorMessage +
+                                "' while deleting the user with id " + provisionedUserId + " from the Azure Active " +
+                                "Directory.");
+                    } else {
+                        log.error("Received response status code: " + response.getStatusLine().getStatusCode() + " "
+                                + response.getStatusLine().getReasonPhrase() + " while deleting the user with id " +
+                                provisionedUserId + " from the Azure Active Directory.");
+                    }
 
                     if (log.isDebugEnabled()) {
                         log.debug("The response received from server : " + jsonResponse.toString());
@@ -307,12 +327,18 @@ public class Office365ProvisioningConnector extends AbstractOutboundProvisioning
                 } else {
                     JSONObject jsonResponse = new JSONObject(new JSONTokener(new InputStreamReader(
                             response.getEntity().getContent())));
-                    String errorMessage = jsonResponse.getJSONObject("error").getString("message");
 
-                    log.error("Received response status code: " + response.getStatusLine().getStatusCode() + " "
-                            + response.getStatusLine().getReasonPhrase() + " with the message '" + errorMessage +
-                            "' while permanently removing the user with id " + provisionedUserId +
-                            " in the Azure Active Directory.");
+                    if (jsonResponse.has("error")) {
+                        String errorMessage = jsonResponse.getJSONObject("error").getString("message");
+                        log.error("Received response status code: " + response.getStatusLine().getStatusCode() + " "
+                                + response.getStatusLine().getReasonPhrase() + " with the message '" + errorMessage +
+                                "' while permanently removing the user with id " + provisionedUserId +
+                                " in the Azure Active Directory.");
+                    } else {
+                        log.error("Received response status code: " + response.getStatusLine().getStatusCode() + " "
+                                + response.getStatusLine().getReasonPhrase() + " while permanently removing the user" +
+                                " with id " + provisionedUserId + " in the Azure Active Directory.");
+                    }
 
                     if (log.isDebugEnabled()) {
                         log.debug("The response received from server : " + jsonResponse.toString());


### PR DESCRIPTION
This PR will add the update functionality of the users that are already provisioned to the Azure AD. So that when the user profile of the user in the Identity Server is updated, those changes are synced with the Azure AD. If the dynamic memberships rules are defined in the Azure AD and configured from the Identity Server, the groups of the user may get updated accordingly. 

The following attributes are defined when provisioning the user for the first time,
* userPrincipalName
* onPremisesImmutableId
* displayName
* mailNickname
* passwordProfile

During the user profile update, passwordProfile update is not supported since it requires special permissions.


